### PR TITLE
Expand CI dependencies to match README requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,22 @@ jobs:
             linux-libc-dev \
             libisl-dev \
             libgtk-3-dev \
+            libcairo2-dev \
+            libpango1.0-dev \
+            libharfbuzz-dev \
+            libgdk-pixbuf-2.0-dev \
+            libatk1.0-dev \
+            libdrm-dev \
+            libusb-1.0-0-dev \
+            libx11-dev \
+            libatspi2.0-dev \
             libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev \
-            libgstreamer-plugins-good1.0-dev
+            libgstreamer-plugins-good1.0-dev \
+            gstreamer1.0-libav
+
+      - name: Clean up local linux stddef shim
+        run: rm -f stddef.h
 
       - name: Build
         run: make


### PR DESCRIPTION
### Motivation
- Ensure the CI runner installs the same development libraries listed in the README so builds on Ubuntu have the required headers and libs.
- Include `gstreamer1.0-libav` to support ffmpeg-backed GStreamer usage required by the project.
- Remove the local `stddef.h` shim from the workspace to avoid header shadowing and related compile failures.

### Description
- Update `.github/workflows/ci.yml` to add Ubuntu dev packages including `libcairo2-dev`, `libpango1.0-dev`, `libharfbuzz-dev`, `libgdk-pixbuf-2.0-dev`, `libatk1.0-dev`, `libdrm-dev`, `libusb-1.0-0-dev`, `libx11-dev`, and `libatspi2.0-dev`.
- Add `gstreamer1.0-libav` to the CI install list to provide ffmpeg-backed GStreamer functionality.
- Retain the existing GTK/GStreamer dev packages and keep the cleanup step `rm -f stddef.h` before running `make`.

### Testing
- No automated tests were run because this change only updates the CI workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c20d360f08320b4826ea835b433e3)