### PR TITLE
Fix Flatpak hardware video output

### DIFF
--- a/video_out.cpp
+++ b/video_out.cpp
@@ -68,10 +68,11 @@ void VideoOut::init_video_screen(GtkWidget *video_screen_parent)
     GstElement *decodebin = gst_element_factory_make("decodebin", "decodebin");
     GstElement *queue = gst_element_factory_make("queue", "queue");
     GstElement *videoconvert = gst_element_factory_make("videoconvert", "videoconvert");
-    GstElement *sink = gst_element_factory_make("autovideosink", "autovideosink");
+    GstElement *sink = gst_element_factory_make("ximagesink", "ximagesink");
 
     g_object_set(G_OBJECT(udpsrc), "uri", "udp://0.0.0.0:11111", NULL);
-    g_object_set(G_OBJECT(queue), "max-size-buffers", 1, "max-size-time", 0, "max-size-bytes", 0, NULL);
+    g_object_set(G_OBJECT(queue), "max-size-buffers", 1, "max-size-time", 0,
+                 "max-size-bytes", 0, "leaky", 2, NULL);
     g_object_set(G_OBJECT(sink), "sync", FALSE, NULL);
 
     GstElement *wifi_label = gst_element_factory_make("textoverlay", "textoverlay1");


### PR DESCRIPTION
## Summary

- use `ximagesink` for the existing X11 video overlay
- retain VA-API hardware H.264 decoding while avoiding the broken VA-to-GL/DMABuf path
- make the one-frame decoded-video queue downstream-leaky to prevent latency buildup

## Validation

The hardware-decoder plus `ximagesink` configuration produced correct video on the Steam Deck. The branch is one commit ahead of `main` and changes only `video_out.cpp`.

A native build was not available in the macOS workspace because GTK and GStreamer development dependencies are not installed.

Closes #12