### PR TITLE
Improve SteamOS Gaming Mode compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "Tello Deck (Freedesktop 24.08 SDK)",
+	"image": "ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-24.08",
+	"remoteUser": "root",
+	"runArgs": [
+		"--privileged"
+	],
+	"mounts": [
+		"source=${localWorkspaceFolderBasename}-flatpak,target=/var/lib/flatpak-user,type=volume"
+	],
+	"containerEnv": {
+		"FLATPAK_USER_DIR": "/var/lib/flatpak-user"
+	},
+	"postCreateCommand": ".devcontainer/post-create.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.makefile-tools",
+				"openai.chatgpt"
+			]
+		}
+	}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             libusb-1.0-0-dev \
             libx11-dev \
             libatspi2.0-dev \
+            libsdl2-dev \
             libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev \
             libgstreamer-plugins-good1.0-dev \

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Transform your Steam Deck into a controller for the DJI Tello drone.
 This project incorporates:
 * GTK-3 for the GUI.
 * GStreamer framework and plug-ins for video and data streaming.
+* SDL2 for Steam Input-compatible controller discovery and hot-plugging.
 * ffmpeg for recording and saving video.
 
 Special thanks to Suphi and his project (https://gitlab.com/Suphi/Tello) for providing the foundation for this app.
@@ -15,8 +16,9 @@ Special thanks to Suphi and his project (https://gitlab.com/Suphi/Tello) for pro
 - <kbd>⧉</kbd>: Start/Stop Recording
 - <kbd>Ⓐ</kbd>: Toggle Speed Mode
 - <kbd>Ⓑ</kbd>: Camera Mode
-- <kbd>Ⓧ</kbd>: Not Assigned
-- <kbd>Ⓨ</kbd>: Scan for Gamepad
+- <kbd>Ⓧ</kbd>: Save Return Position
+- <kbd>Ⓨ</kbd>: Toggle Return Mode
+- <kbd>F11</kbd>: Toggle Fullscreen
 ![](ScreenShot.jpg)
 
 ## Installation
@@ -32,7 +34,7 @@ make PREFIX=/usr install
 ## Flatpak on SteamOS
 
 Flatpak is the recommended installation method on SteamOS. The Flatpak contains
-the application and FFmpeg, while GTK, GStreamer, Cairo, Pango, HarfBuzz and
+the application, SDL2, and FFmpeg, while GTK, GStreamer, Cairo, Pango, HarfBuzz and
 GDK-Pixbuf are supplied by the pinned GNOME runtime. It does not require
 disabling SteamOS read-only mode or installing these libraries with `pacman`.
 
@@ -45,8 +47,9 @@ flatpak run io.github.mrzinger.TelloDeck
 ```
 
 The first command installs the required GNOME runtime automatically. Tello Deck
-needs network access for the drone's UDP connection, direct device access for
-the Steam Deck controls, and access to the Videos directory for recordings.
+needs network access for the drone's UDP connection, device access for SDL
+controller input, and access to the Videos directory for recordings. It uses
+native Wayland when available and falls back to XWayland.
 
 After installation, add the **Tello Deck** application to Steam as a non-Steam
 game to launch it from Gaming Mode.
@@ -70,9 +73,9 @@ or
 sudo btrfs property set -ts / ro false
 ```
 ### Installing development tools
-Install `gcc` and `pkg-config`:
+Install `gcc`, `pkg-config`, and SDL2:
 ```bash
-sudo pacman -S gcc pkg-config
+sudo pacman -S gcc pkg-config sdl2
 ```
 
 ### Install dependencies and libraries
@@ -89,9 +92,9 @@ Install libs needed for overlays
 ```bash
 sudo pacman -S cairo pango harfbuzz gdk-pixbuf2 
 ```
-Install X Window related libraries
+Install GTK 3 and its accessibility libraries
 ```bash
-sudo pacman -S xorgproto libx11 at-spi2-core 
+sudo pacman -S gtk3 at-spi2-core
 ```
 ### For further development
 To support network management capabilities and be able to automatically join Tello's Wi-fi network we will need `libnm` and `glib2`

--- a/io.github.mrzinger.TelloDeck.yml
+++ b/io.github.mrzinger.TelloDeck.yml
@@ -1,7 +1,7 @@
 id: io.github.mrzinger.TelloDeck
-runtime: org.gnome.Platform
-runtime-version: '50'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
 command: tello
 
 finish-args:

--- a/io.github.mrzinger.TelloDeck.yml
+++ b/io.github.mrzinger.TelloDeck.yml
@@ -7,16 +7,34 @@ command: tello
 finish-args:
   # The application receives control and video data from the drone over UDP.
   - --share=network
-  # GTK 3's X11 video overlay needs X11 and shared-memory access.
+  # Prefer native Wayland while retaining XWayland support for Gaming Mode.
   - --share=ipc
-  - --socket=x11
-  # Tello Deck currently reads the Steam Deck controller from /dev/input.
-  # This also grants the DRI device access needed for video output.
+  - --socket=wayland
+  - --socket=fallback-x11
+  # SDL reads Steam Input's virtual controller from the host input devices.
   - --device=all
   # Recordings are saved in the user's Videos directory.
   - --filesystem=xdg-videos
 
 modules:
+  - name: sdl2
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --enable-shared
+      - --disable-audio
+      - --disable-video
+      - --disable-render
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+      - '*.la'
+    sources:
+      - type: git
+        url: https://github.com/libsdl-org/SDL.git
+        commit: 5d249570393f7a37e037abf22cd6012a4cc56a71
+
   # The app invokes the ffmpeg CLI when recording. Build a deliberately small
   # copy containing only the raw-H.264-to-MP4 stream-copy functionality used by
   # Tello Deck, instead of depending on packages installed on SteamOS.

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ CXX ?= g++
 PKG_CONFIG ?= pkg-config
 
 APP_ID = io.github.mrzinger.TelloDeck
-PKGS = gtk+-3.0 gstreamer-1.0 sdl2
+PKGS = gtk+-3.0 gdk-x11-3.0 gstreamer-1.0 gstreamer-video-1.0 sdl2
 SRCDIR := src
 BUILDDIR := build
 TARGET := tello
@@ -26,6 +26,23 @@ CXXFLAGS += -Wall -pthread
 LDLIBS += -lm -pthread $(shell $(PKG_CONFIG) --libs $(PKGS))
 
 all: $(TARGET)
+
+# The devcontainer itself is the Freedesktop SDK, so this target builds against
+# the same headers and libraries used by the Flatpak manifest.
+sdk: all
+
+flatpak:
+	flatpak-builder --user --force-clean --disable-rofiles-fuse \
+		--install-deps-from=flathub \
+		build-dir io.github.mrzinger.TelloDeck.yml
+
+flatpak-install:
+	flatpak-builder --user --force-clean --disable-rofiles-fuse --install \
+		--install-deps-from=flathub \
+		build-dir io.github.mrzinger.TelloDeck.yml
+
+flatpak-run:
+	flatpak run $(APP_ID)
 
 $(TARGET): $(OBJECTS)
 	$(CXX) $(OBJECTS) -o $@ $(LDFLAGS) $(LDLIBS)
@@ -60,4 +77,4 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/share/metainfo/$(APP_ID).metainfo.xml
 	rm -f $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/$(APP_ID).svg
 
-.PHONY: all clean install uninstall
+.PHONY: all sdk flatpak flatpak-install flatpak-run clean install uninstall

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ CXX ?= g++
 PKG_CONFIG ?= pkg-config
 
 APP_ID = io.github.mrzinger.TelloDeck
-PKGS = gtk+-3.0 gdk-x11-3.0 gstreamer-1.0 gstreamer-video-1.0
+PKGS = gtk+-3.0 gstreamer-1.0 sdl2
 SRCDIR := src
 BUILDDIR := build
 TARGET := tello

--- a/src/tello_app.cpp
+++ b/src/tello_app.cpp
@@ -363,9 +363,9 @@ void TelloApp::connection_thread_entry(TelloApp *self)
 
 void TelloApp::create_button(const char *icon, GtkWidget *container, int toggle)
 {
-    static const char *labels[MAX_BUTTONS] = {
-        "Video", "View · Record", "B · Camera", "A · Speed",
-        "Menu · Fly", "Y · Return"
+    static const char *descriptions[MAX_BUTTONS] = {
+        "Video", "Record", "Camera", "Speed",
+        "Take off or land", "Return"
     };
     GtkWidget *button;
     if (toggle == 0) {
@@ -377,9 +377,9 @@ void TelloApp::create_button(const char *icon, GtkWidget *container, int toggle)
         gtk_button_set_image(GTK_BUTTON(button), image);
         g_signal_connect(button, "toggled", G_CALLBACK(TelloApp::button_callback_static), (gpointer)(long)button_amount);
     }
-    gtk_button_set_label(GTK_BUTTON(button), labels[button_amount]);
-    gtk_button_set_always_show_image(GTK_BUTTON(button), TRUE);
-    gtk_widget_set_size_request(button, 112, 56);
+    gtk_widget_set_tooltip_text(button, descriptions[button_amount]);
+    atk_object_set_name(gtk_widget_get_accessible(button), descriptions[button_amount]);
+    gtk_widget_set_size_request(button, 56, 56);
     gtk_action_bar_pack_start(GTK_ACTION_BAR(container), button);
     buttons[button_amount] = button;
     button_amount++;
@@ -412,12 +412,12 @@ void TelloApp::on_activate(GtkApplication *app)
     GtkWidget *actionbar = gtk_action_bar_new();
     gtk_box_pack_start(GTK_BOX(vbox), actionbar, FALSE, TRUE, 0);
 
-    create_button("camera-video", actionbar, 1);
-    create_button("media-floppy", actionbar, 1);
-    create_button("video-display", actionbar, 1);
-    create_button("speedometer", actionbar, 1);
-    create_button("pan-up", actionbar, 1);
-    create_button("input-gaming", actionbar, 1);
+    create_button("camera-video-symbolic", actionbar, 1);
+    create_button("media-record-symbolic", actionbar, 1);
+    create_button("video-display-symbolic", actionbar, 1);
+    create_button("speedometer-symbolic", actionbar, 1);
+    create_button("pan-up-symbolic", actionbar, 1);
+    create_button("input-gaming-symbolic", actionbar, 1);
 
     infolabel = gtk_label_new("");
     gtk_action_bar_pack_end(GTK_ACTION_BAR(actionbar), infolabel);

--- a/src/tello_app.cpp
+++ b/src/tello_app.cpp
@@ -1,13 +1,8 @@
 #include "tello_app.h"
-#include <fcntl.h>
-#include <linux/input.h>
 #include <math.h>
 #include <thread>
-#include <gdk/gdkx.h>
-#include <gst/video/videooverlay.h>
 #include <gtk/gtk.h>
 #include <gst/gst.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
 #include <signal.h>
 #include <stdio.h>
@@ -19,7 +14,8 @@
 TelloApp *TelloApp::instance = nullptr;
 
 TelloApp::TelloApp()
-    : infolabel(nullptr), pid1(0), pid2(0), button_amount(0), input_file(0),
+    : infolabel(nullptr), main_window(nullptr), pid1(0), pid2(0),
+      button_amount(0), controller(nullptr), controller_poll_source(0),
       sky(0), battery_percentage(0), wifi_strength(0), height(0),
       fly_speed(0), fly_time(0), targetPosition_x(0), targetPosition_y(0),
       targetPosition_z(0), targetDistance(0)
@@ -30,39 +26,40 @@ TelloApp::TelloApp()
     targetDirection[1] = 1;
 }
 
-void TelloApp::input_key(int code, int value)
+void TelloApp::controller_button(SDL_GameControllerButton button)
 {
-    if (value != 1) return;
-    switch (code) {
-    case BTN_START:
+    switch (button) {
+    case SDL_CONTROLLER_BUTTON_START:
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(buttons[4]),
             !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(buttons[4])));
         return;
-    case BTN_SELECT:
+    case SDL_CONTROLLER_BUTTON_BACK:
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(buttons[1]),
             !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(buttons[1])));
         return;
-    case BTN_A:
+    case SDL_CONTROLLER_BUTTON_A:
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(buttons[3]),
             !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(buttons[3])));
         return;
-    case BTN_B:
+    case SDL_CONTROLLER_BUTTON_B:
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(buttons[2]),
             !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(buttons[2])));
         return;
-    case BTN_X:
+    case SDL_CONTROLLER_BUTTON_X:
         targetPosition_x = tello.position_x;
         targetPosition_y = tello.position_y;
         targetPosition_z = tello.position_z;
         return;
-    case BTN_Y:
+    case SDL_CONTROLLER_BUTTON_Y:
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(buttons[5]),
             !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(buttons[5])));
+        return;
+    default:
         return;
     }
 }
 
-void TelloApp::input_abs(int code, int value)
+void TelloApp::controller_axis(SDL_GameControllerAxis axis, Sint16 value)
 {
     float v = (value + 0.5) / 32767.5;
     if (v > -0.2 && v < 0.2) v = 0;
@@ -70,69 +67,79 @@ void TelloApp::input_abs(int code, int value)
         if (v == 0) return;
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(buttons[5]), FALSE);
     }
-    switch (code) {
-        case ABS_X: tello.left_x = v; break;
-        case ABS_Y: tello.left_y = -v; break;
-        case ABS_RX: tello.right_x = v; break;
-        case ABS_RY: tello.right_y = -v; break;
+    switch (axis) {
+        case SDL_CONTROLLER_AXIS_LEFTX: tello.left_x = v; break;
+        case SDL_CONTROLLER_AXIS_LEFTY: tello.left_y = -v; break;
+        case SDL_CONTROLLER_AXIS_RIGHTX: tello.right_x = v; break;
+        case SDL_CONTROLLER_AXIS_RIGHTY: tello.right_y = -v; break;
+        default: break;
     }
 }
 
-void TelloApp::input_thread()
+void TelloApp::close_controller()
 {
-    struct input_event event[8];
-    while (input_file > 0) {
-        int count = read(input_file, &event, sizeof(event)) / sizeof(struct input_event);
-        for (int i = 0; i < count; i++) {
-            switch (event[i].type) {
-            case EV_KEY: input_key(event[i].code, event[i].value); break;
-            case EV_ABS: input_abs(event[i].code, event[i].value); break;
-            }
-        }
-    }
+    if (controller == nullptr) return;
+    SDL_GameControllerClose(controller);
+    controller = nullptr;
 }
 
-void TelloApp::input_thread_entry(TelloApp *self)
+int TelloApp::open_controller(int device_index)
 {
-    self->input_thread();
-}
+    if (controller != nullptr && SDL_GameControllerGetAttached(controller))
+        return 0;
 
-int TelloApp::input_has(int fd, uint16_t type, uint16_t code)
-{
-    size_t nchar = KEY_MAX/8 + 1;
-    unsigned char bits[nchar];
-    ioctl(fd, EVIOCGBIT(type, sizeof(bits)), &bits);
-    return bits[code/8] & (1 << (code % 8));
-}
-
-void TelloApp::close_input()
-{
-    if (input_file == 0) return;
-    close(input_file);
-    input_file = 0;
-}
-
-int TelloApp::open_input()
-{
-    close_input();
-    char path[32];
-    for (int i = 0; i < 32; i++) {
-        sprintf(path, "/dev/input/event%d", i);
-        if (access(path, F_OK) < 0) return -1;
-        int file = open(path, O_RDONLY);
-        if (file <= 0) continue;
-        if (input_has(file, EV_ABS, ABS_X) && input_has(file, EV_ABS, ABS_Y) &&
-            input_has(file, EV_ABS, ABS_RX) && input_has(file, EV_ABS, ABS_RY)) {
-            char name[256];
-            ioctl(file, EVIOCGNAME(sizeof(name)), name);
-            printf("Input: %s\n", name);
-            input_file = file;
-            std::thread(&TelloApp::input_thread_entry, this).detach();
+    close_controller();
+    int first = device_index >= 0 ? device_index : 0;
+    int last = device_index >= 0 ? device_index + 1 : SDL_NumJoysticks();
+    for (int i = first; i < last; ++i) {
+        if (!SDL_IsGameController(i)) continue;
+        controller = SDL_GameControllerOpen(i);
+        if (controller != nullptr) {
+            printf("Controller: %s\n", SDL_GameControllerName(controller));
             return 0;
         }
-        close(file);
     }
+    fprintf(stderr, "No game controller found: %s\n", SDL_GetError());
     return -1;
+}
+
+gboolean TelloApp::poll_controller()
+{
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+        switch (event.type) {
+        case SDL_CONTROLLERDEVICEADDED:
+            if (controller == nullptr) open_controller(event.cdevice.which);
+            break;
+        case SDL_CONTROLLERDEVICEREMOVED:
+            if (controller != nullptr &&
+                SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller)) ==
+                    event.cdevice.which) {
+                close_controller();
+                open_controller();
+            }
+            break;
+        case SDL_CONTROLLERBUTTONDOWN:
+            if (controller != nullptr &&
+                SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller)) ==
+                    event.cbutton.which)
+                controller_button(static_cast<SDL_GameControllerButton>(event.cbutton.button));
+            break;
+        case SDL_CONTROLLERAXISMOTION:
+            if (controller != nullptr &&
+                SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller)) ==
+                    event.caxis.which)
+                controller_axis(static_cast<SDL_GameControllerAxis>(event.caxis.axis),
+                                event.caxis.value);
+            break;
+        }
+    }
+    return G_SOURCE_CONTINUE;
+}
+
+gboolean TelloApp::poll_controller_static(gpointer ptr)
+{
+    return static_cast<TelloApp*>(ptr)->poll_controller();
 }
 
 gboolean TelloApp::key_callback(GtkWidget *widget, GdkEventKey *event)
@@ -143,7 +150,14 @@ gboolean TelloApp::key_callback(GtkWidget *widget, GdkEventKey *event)
             !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(buttons[4])));
         return TRUE;
     case GDK_KEY_Return:
-        open_input();
+        open_controller();
+        return TRUE;
+    case GDK_KEY_F11:
+        if (gdk_window_get_state(gtk_widget_get_window(main_window)) &
+            GDK_WINDOW_STATE_FULLSCREEN)
+            gtk_window_unfullscreen(GTK_WINDOW(main_window));
+        else
+            gtk_window_fullscreen(GTK_WINDOW(main_window));
         return TRUE;
     }
     return FALSE;
@@ -321,8 +335,6 @@ void TelloApp::tello_camera_callback_static(uint8_t *data, int size)
 
 void TelloApp::connection_thread()
 {
-    open_input();
-
     while (tello.connect(6038, 2) < 0) printf("Connection Failed\n");
     printf("Connected\n");
 
@@ -351,6 +363,10 @@ void TelloApp::connection_thread_entry(TelloApp *self)
 
 void TelloApp::create_button(const char *icon, GtkWidget *container, int toggle)
 {
+    static const char *labels[MAX_BUTTONS] = {
+        "Video", "View · Record", "B · Camera", "A · Speed",
+        "Menu · Fly", "Y · Return"
+    };
     GtkWidget *button;
     if (toggle == 0) {
         button = gtk_button_new_from_icon_name(icon, GTK_ICON_SIZE_BUTTON);
@@ -361,6 +377,9 @@ void TelloApp::create_button(const char *icon, GtkWidget *container, int toggle)
         gtk_button_set_image(GTK_BUTTON(button), image);
         g_signal_connect(button, "toggled", G_CALLBACK(TelloApp::button_callback_static), (gpointer)(long)button_amount);
     }
+    gtk_button_set_label(GTK_BUTTON(button), labels[button_amount]);
+    gtk_button_set_always_show_image(GTK_BUTTON(button), TRUE);
+    gtk_widget_set_size_request(button, 112, 56);
     gtk_action_bar_pack_start(GTK_ACTION_BAR(container), button);
     buttons[button_amount] = button;
     button_amount++;
@@ -369,20 +388,19 @@ void TelloApp::create_button(const char *icon, GtkWidget *container, int toggle)
 void TelloApp::on_activate(GtkApplication *app)
 {
     GtkWidget *window = gtk_application_window_new(app);
+    main_window = window;
     gtk_window_set_title(GTK_WINDOW(window), "Tello");
-    gtk_window_set_icon_name (GTK_WINDOW(window), "gpsd-logo");
+    gtk_window_set_icon_name(GTK_WINDOW(window), "io.github.mrzinger.TelloDeck");
     gtk_window_set_default_size(GTK_WINDOW(window), 1200, 800);
     g_signal_connect(window, "key_press_event", G_CALLBACK(TelloApp::key_callback_static), this);
 
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_container_add(GTK_CONTAINER(window), vbox);
 
-    GtkWidget *video_screen = gtk_drawing_area_new();
+    GtkWidget *video_screen = video_out.init_video_screen();
     gtk_widget_set_vexpand(video_screen, TRUE);
     gtk_widget_set_hexpand(video_screen, TRUE);
     gtk_box_pack_start(GTK_BOX(vbox), video_screen, TRUE, TRUE, 0);
-
-    video_out.init_video_screen(video_screen);
 
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 4);
     gtk_box_set_homogeneous(GTK_BOX(box), TRUE);
@@ -406,6 +424,15 @@ void TelloApp::on_activate(GtkApplication *app)
 
     gtk_widget_show_all(window);
 
+    if (g_getenv("SteamGameId") != nullptr || g_getenv("SteamAppId") != nullptr) {
+        gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+        gtk_window_fullscreen(GTK_WINDOW(window));
+    }
+
+    open_controller();
+    if (controller_poll_source == 0)
+        controller_poll_source = g_timeout_add(16, poll_controller_static, this);
+
     std::thread(&TelloApp::connection_thread_entry, this).detach();
 }
 
@@ -417,15 +444,27 @@ void TelloApp::on_activate_static(GtkApplication *app, gpointer user_data)
 
 int TelloApp::run(int argc, char *argv[])
 {
+    const Uint32 controller_subsystems = SDL_INIT_GAMECONTROLLER | SDL_INIT_EVENTS;
+
     instance = this;
     tello.camera_callback = NULL;
     tello.data_callback = NULL;
+
+    SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+    if (SDL_InitSubSystem(controller_subsystems) < 0)
+        fprintf(stderr, "Could not initialize controller support: %s\n", SDL_GetError());
+
     GtkApplication *app = gtk_application_new("io.github.mrzinger.TelloDeck", G_APPLICATION_DEFAULT_FLAGS);
     g_signal_connect(app, "activate", G_CALLBACK(TelloApp::on_activate_static), this);
     int status = g_application_run(G_APPLICATION(app), argc, argv);
     g_object_unref(app);
 
     tello.disconnect();
-    close_input();
+    if (controller_poll_source != 0) {
+        g_source_remove(controller_poll_source);
+        controller_poll_source = 0;
+    }
+    close_controller();
+    SDL_QuitSubSystem(controller_subsystems);
     return status;
 }

--- a/src/tello_app.h
+++ b/src/tello_app.h
@@ -3,6 +3,7 @@
 
 #include "tello.h"
 #include "video_out.h"
+#include <SDL.h>
 #include <gtk/gtk.h>
 #include <gst/gst.h>
 #include <sys/types.h>
@@ -31,10 +32,12 @@ private:
     VideoOut video_out;
     GtkWidget *buttons[MAX_BUTTONS];
     GtkWidget *infolabel;
+    GtkWidget *main_window;
     pid_t pid1;
     pid_t pid2;
     int button_amount;
-    int input_file;
+    SDL_GameController *controller;
+    guint controller_poll_source;
     Socket camera_socket1;
     Socket camera_socket2;
     struct sockaddr_in camera_address1;
@@ -52,13 +55,12 @@ private:
     float targetDirection[2];
     float targetDistance;
 
-    void input_key(int code, int value);
-    void input_abs(int code, int value);
-    void input_thread();
-    static void input_thread_entry(TelloApp *self);
-    int input_has(int fd, uint16_t type, uint16_t code);
-    void close_input();
-    int open_input();
+    void controller_button(SDL_GameControllerButton button);
+    void controller_axis(SDL_GameControllerAxis axis, Sint16 value);
+    void close_controller();
+    int open_controller(int device_index = -1);
+    gboolean poll_controller();
+    static gboolean poll_controller_static(gpointer ptr);
 
     static gboolean key_callback_static(GtkWidget *widget, GdkEventKey *event, gpointer ptr);
     gboolean key_callback(GtkWidget *widget, GdkEventKey *event);

--- a/src/video_out.cpp
+++ b/src/video_out.cpp
@@ -1,9 +1,10 @@
 #include "video_out.h"
+#include <gdk/gdkx.h>
 #include <stdlib.h>
 
 const char *VideoOut::g_def_label[MAX_LBL] = {"📶Wifi:", "↑Alt:", "🔋Bat:"};
 
-VideoOut::VideoOut() : pipeline(NULL) {
+VideoOut::VideoOut() : pipeline(NULL), video_sink(NULL) {
     for (int i = 0; i < MAX_LBL; ++i) g_video_lbls[i] = NULL;
 }
 
@@ -29,6 +30,34 @@ void VideoOut::gst_pad_link_elements(GstElement *element, GstPad *pad, gpointer 
     gst_object_unref(sinkpad);
 }
 
+GstBusSyncReply VideoOut::bus_sync_handler(GstBus *bus, GstMessage *message, gpointer data)
+{
+    VideoOut *self = static_cast<VideoOut*>(data);
+    if (!gst_is_video_overlay_prepare_window_handle_message(message))
+        return GST_BUS_PASS;
+
+    GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(g_object_get_data(
+        G_OBJECT(self->video_sink), "video-widget")));
+    if (window != NULL)
+        gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(GST_MESSAGE_SRC(message)),
+                                            GDK_WINDOW_XID(window));
+
+    gst_message_unref(message);
+    return GST_BUS_DROP;
+}
+
+void VideoOut::realize_x11_video_widget(GtkWidget *widget, gpointer data)
+{
+    VideoOut *self = static_cast<VideoOut*>(data);
+    GdkWindow *window = gtk_widget_get_window(widget);
+    if (window == NULL || !gdk_window_ensure_native(window)) {
+        g_warning("Could not create a native X11 window for video output");
+        return;
+    }
+
+    g_object_set_data(G_OBJECT(self->video_sink), "video-widget", widget);
+}
+
 GtkWidget *VideoOut::init_video_screen()
 {
     gst_init(NULL, NULL);
@@ -37,21 +66,36 @@ GtkWidget *VideoOut::init_video_screen()
     GstElement *decodebin = gst_element_factory_make("decodebin", "decodebin");
     GstElement *queue = gst_element_factory_make("queue", "queue");
     GstElement *videoconvert = gst_element_factory_make("videoconvert", "videoconvert");
-    GstElement *gtk_sink = gst_element_factory_make("gtkglsink", "gtkglsink");
-    GstElement *sink = gst_element_factory_make("glsinkbin", "glsinkbin");
+    const gboolean use_x11_sink = GDK_IS_X11_DISPLAY(gdk_display_get_default());
+    GstElement *gtk_sink = NULL;
+    GstElement *sink = NULL;
     GstElement *wifi_label = gst_element_factory_make("textoverlay", "textoverlay1");
     GstElement *alt_label = gst_element_factory_make("textoverlay", "textoverlay2");
     GstElement *bat_label = gst_element_factory_make("textoverlay", "textoverlay3");
 
-    if (!udpsrc || !decodebin || !queue || !videoconvert || !gtk_sink || !sink ||
+    if (use_x11_sink)
+        sink = gst_element_factory_make("ximagesink", "ximagesink");
+    else {
+        gtk_sink = gst_element_factory_make("gtkglsink", "gtkglsink");
+        sink = gst_element_factory_make("glsinkbin", "glsinkbin");
+    }
+
+    if (!udpsrc || !decodebin || !queue || !videoconvert || !sink ||
+        (!use_x11_sink && !gtk_sink) ||
         !wifi_label || !alt_label || !bat_label) {
         g_warning("Could not create the GStreamer video elements");
         return gtk_label_new("Video output is unavailable");
     }
 
     GtkWidget *video_widget = NULL;
-    g_object_set(G_OBJECT(sink), "sink", gtk_sink, NULL);
-    g_object_get(G_OBJECT(gtk_sink), "widget", &video_widget, NULL);
+    if (use_x11_sink) {
+        video_widget = gtk_drawing_area_new();
+        g_signal_connect(video_widget, "realize",
+                         G_CALLBACK(VideoOut::realize_x11_video_widget), this);
+    } else {
+        g_object_set(G_OBJECT(sink), "sink", gtk_sink, NULL);
+        g_object_get(G_OBJECT(gtk_sink), "widget", &video_widget, NULL);
+    }
     if (video_widget == NULL) {
         g_warning("Could not create the GTK video widget");
         return gtk_label_new("Video output is unavailable");
@@ -61,6 +105,7 @@ GtkWidget *VideoOut::init_video_screen()
     g_object_set(G_OBJECT(queue), "max-size-buffers", 1, "max-size-time", 0,
                  "max-size-bytes", 0, "leaky", 2, NULL);
     g_object_set(G_OBJECT(sink), "sync", FALSE, NULL);
+    video_sink = sink;
 
     const char *font = "Hack, 10";
     g_object_set(G_OBJECT(wifi_label), "name", "wifi_label", "font-desc", font,
@@ -92,6 +137,11 @@ GtkWidget *VideoOut::init_video_screen()
     }
 
     g_signal_connect(decodebin, "pad-added", G_CALLBACK(VideoOut::gst_pad_link_elements), queue);
+    if (use_x11_sink) {
+        GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
+        gst_bus_set_sync_handler(bus, VideoOut::bus_sync_handler, this, NULL);
+        gst_object_unref(bus);
+    }
     return video_widget;
 }
 

--- a/src/video_out.cpp
+++ b/src/video_out.cpp
@@ -72,6 +72,7 @@ GtkWidget *VideoOut::init_video_screen()
     GstElement *wifi_label = gst_element_factory_make("textoverlay", "textoverlay1");
     GstElement *alt_label = gst_element_factory_make("textoverlay", "textoverlay2");
     GstElement *bat_label = gst_element_factory_make("textoverlay", "textoverlay3");
+    GstElement *overlay_blend = gst_element_factory_make("identity", "overlay_blend");
 
     if (use_x11_sink)
         sink = gst_element_factory_make("ximagesink", "ximagesink");
@@ -82,7 +83,7 @@ GtkWidget *VideoOut::init_video_screen()
 
     if (!udpsrc || !decodebin || !queue || !videoconvert || !sink ||
         (!use_x11_sink && !gtk_sink) ||
-        !wifi_label || !alt_label || !bat_label) {
+        !wifi_label || !alt_label || !bat_label || !overlay_blend) {
         g_warning("Could not create the GStreamer video elements");
         return gtk_label_new("Video output is unavailable");
     }
@@ -105,6 +106,10 @@ GtkWidget *VideoOut::init_video_screen()
     g_object_set(G_OBJECT(queue), "max-size-buffers", 1, "max-size-time", 0,
                  "max-size-bytes", 0, "leaky", 2, NULL);
     g_object_set(G_OBJECT(sink), "sync", FALSE, NULL);
+    // GL sinks advertise GstVideoOverlayComposition support. Without an
+    // allocation barrier, chained textoverlay elements can replace each
+    // other's composition metadata instead of blending every label.
+    g_object_set(G_OBJECT(overlay_blend), "drop-allocation", TRUE, NULL);
     video_sink = sink;
 
     const char *font = "Hack, 10";
@@ -122,7 +127,7 @@ GtkWidget *VideoOut::init_video_screen()
     pipeline = gst_pipeline_new("pipeline");
 
     gst_bin_add_many(GST_BIN(pipeline), udpsrc, decodebin, queue, videoconvert,
-                     wifi_label, alt_label, bat_label, sink, NULL);
+                     bat_label, wifi_label, alt_label, overlay_blend, sink, NULL);
 
     if (!gst_element_link(udpsrc, decodebin))
     {
@@ -130,7 +135,8 @@ GtkWidget *VideoOut::init_video_screen()
         return video_widget;
     }
 
-    if (!gst_element_link_many(queue, videoconvert, wifi_label, alt_label, bat_label, sink, NULL))
+    if (!gst_element_link_many(queue, videoconvert, bat_label, wifi_label, alt_label,
+                               overlay_blend, sink, NULL))
     {
         g_printerr("Failed to link the video processing pipeline.\n");
         return video_widget;

--- a/src/video_out.cpp
+++ b/src/video_out.cpp
@@ -3,52 +3,21 @@
 
 const char *VideoOut::g_def_label[MAX_LBL] = {"📶Wifi:", "↑Alt:", "🔋Bat:"};
 
-VideoOut::VideoOut() : pipeline(NULL), video_window_handle(0) {
+VideoOut::VideoOut() : pipeline(NULL) {
     for (int i = 0; i < MAX_LBL; ++i) g_video_lbls[i] = NULL;
+}
+
+VideoOut::~VideoOut()
+{
+    if (pipeline == NULL) return;
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
 }
 
 void VideoOut::start_video()
 {
-    gst_element_set_state(pipeline, GST_STATE_PLAYING);
-}
-
-GstBusSyncReply VideoOut::bus_sync_handler(GstBus *bus, GstMessage *message, gpointer user_data)
-{
-    VideoOut *self = static_cast<VideoOut*>(user_data);
-    if (!gst_is_video_overlay_prepare_window_handle_message(message))
-        return GST_BUS_PASS;
-
-    if (self->video_window_handle != 0)
-    {
-        GstVideoOverlay *overlay = GST_VIDEO_OVERLAY(GST_MESSAGE_SRC(message));
-        gst_video_overlay_set_window_handle(overlay, self->video_window_handle);
-    }
-    else
-    {
-        g_warning("Should have obtained video_window_handle by now!");
-    }
-
-    gst_message_unref(message);
-    return GST_BUS_DROP;
-}
-
-void VideoOut::realize_cb(GtkWidget *widget, gpointer data)
-{
-    VideoOut *self = static_cast<VideoOut*>(data);
-    GdkWindow *window = gtk_widget_get_window(widget);
-
-    if (!gdk_window_ensure_native(window))
-        g_error("Couldn't create native window needed for GstVideoOverlay");
-
-    self->video_window_handle = GDK_WINDOW_XID(window);
-}
-
-gboolean VideoOut::delete_event_cb(GtkWidget *widget, GdkEvent *event, gpointer data)
-{
-    VideoOut *self = static_cast<VideoOut*>(data);
-    gst_element_set_state(self->pipeline, GST_STATE_NULL);
-    gst_object_unref(self->pipeline);
-    return FALSE;
+    if (pipeline != NULL)
+        gst_element_set_state(pipeline, GST_STATE_PLAYING);
 }
 
 void VideoOut::gst_pad_link_elements(GstElement *element, GstPad *pad, gpointer data)
@@ -60,7 +29,7 @@ void VideoOut::gst_pad_link_elements(GstElement *element, GstPad *pad, gpointer 
     gst_object_unref(sinkpad);
 }
 
-void VideoOut::init_video_screen(GtkWidget *video_screen_parent)
+GtkWidget *VideoOut::init_video_screen()
 {
     gst_init(NULL, NULL);
 
@@ -68,16 +37,30 @@ void VideoOut::init_video_screen(GtkWidget *video_screen_parent)
     GstElement *decodebin = gst_element_factory_make("decodebin", "decodebin");
     GstElement *queue = gst_element_factory_make("queue", "queue");
     GstElement *videoconvert = gst_element_factory_make("videoconvert", "videoconvert");
-    GstElement *sink = gst_element_factory_make("ximagesink", "ximagesink");
+    GstElement *gtk_sink = gst_element_factory_make("gtkglsink", "gtkglsink");
+    GstElement *sink = gst_element_factory_make("glsinkbin", "glsinkbin");
+    GstElement *wifi_label = gst_element_factory_make("textoverlay", "textoverlay1");
+    GstElement *alt_label = gst_element_factory_make("textoverlay", "textoverlay2");
+    GstElement *bat_label = gst_element_factory_make("textoverlay", "textoverlay3");
+
+    if (!udpsrc || !decodebin || !queue || !videoconvert || !gtk_sink || !sink ||
+        !wifi_label || !alt_label || !bat_label) {
+        g_warning("Could not create the GStreamer video elements");
+        return gtk_label_new("Video output is unavailable");
+    }
+
+    GtkWidget *video_widget = NULL;
+    g_object_set(G_OBJECT(sink), "sink", gtk_sink, NULL);
+    g_object_get(G_OBJECT(gtk_sink), "widget", &video_widget, NULL);
+    if (video_widget == NULL) {
+        g_warning("Could not create the GTK video widget");
+        return gtk_label_new("Video output is unavailable");
+    }
 
     g_object_set(G_OBJECT(udpsrc), "uri", "udp://0.0.0.0:11111", NULL);
     g_object_set(G_OBJECT(queue), "max-size-buffers", 1, "max-size-time", 0,
                  "max-size-bytes", 0, "leaky", 2, NULL);
     g_object_set(G_OBJECT(sink), "sync", FALSE, NULL);
-
-    GstElement *wifi_label = gst_element_factory_make("textoverlay", "textoverlay1");
-    GstElement *alt_label = gst_element_factory_make("textoverlay", "textoverlay2");
-    GstElement *bat_label = gst_element_factory_make("textoverlay", "textoverlay3");
 
     const char *font = "Hack, 10";
     g_object_set(G_OBJECT(wifi_label), "name", "wifi_label", "font-desc", font,
@@ -99,27 +82,22 @@ void VideoOut::init_video_screen(GtkWidget *video_screen_parent)
     if (!gst_element_link(udpsrc, decodebin))
     {
         g_printerr("Failed to link udpsrc and decodebin.\n");
-        return;
+        return video_widget;
     }
 
     if (!gst_element_link_many(queue, videoconvert, wifi_label, alt_label, bat_label, sink, NULL))
     {
-        g_printerr("Failed to link queue, videoconvert, and autovideosink.\n");
-        return;
+        g_printerr("Failed to link the video processing pipeline.\n");
+        return video_widget;
     }
 
     g_signal_connect(decodebin, "pad-added", G_CALLBACK(VideoOut::gst_pad_link_elements), queue);
-
-    g_signal_connect(video_screen_parent, "realize", G_CALLBACK(VideoOut::realize_cb), this);
-    g_signal_connect(video_screen_parent, "delete-event", G_CALLBACK(VideoOut::delete_event_cb), this);
-
-    GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
-    gst_bus_set_sync_handler(bus, (GstBusSyncHandler)VideoOut::bus_sync_handler, this, NULL);
-    gst_object_unref(bus);
+    return video_widget;
 }
 
 void VideoOut::set_label(VideoLabels label_id, const char *text)
 {
+    if (g_video_lbls[label_id] == NULL) return;
     char label[64];
     sprintf(label, "%s %s", g_def_label[label_id], text);
     g_object_set(G_OBJECT(g_video_lbls[label_id]), "text", label, NULL);

--- a/src/video_out.h
+++ b/src/video_out.h
@@ -2,6 +2,7 @@
 #define _VIDEO_OUT_H_
 
 #include <gst/gst.h>
+#include <gst/video/videooverlay.h>
 #include <gtk/gtk.h>
 
 typedef enum {
@@ -22,10 +23,13 @@ public:
 
 private:
     GstElement *pipeline;
+    GstElement *video_sink;
     GstElement *g_video_lbls[MAX_LBL];
     static const char *g_def_label[MAX_LBL];
 
     static void gst_pad_link_elements(GstElement *element, GstPad *pad, gpointer data);
+    static GstBusSyncReply bus_sync_handler(GstBus *bus, GstMessage *message, gpointer data);
+    static void realize_x11_video_widget(GtkWidget *widget, gpointer data);
 };
 
 #endif /* _VIDEO_OUT_H_ */

--- a/src/video_out.h
+++ b/src/video_out.h
@@ -2,8 +2,6 @@
 #define _VIDEO_OUT_H_
 
 #include <gst/gst.h>
-#include <gdk/gdkx.h>
-#include <gst/video/videooverlay.h>
 #include <gtk/gtk.h>
 
 typedef enum {
@@ -16,20 +14,17 @@ typedef enum {
 class VideoOut {
 public:
     VideoOut();
+    ~VideoOut();
 
-    void init_video_screen(GtkWidget *video_screen_parent);
+    GtkWidget *init_video_screen();
     void set_label(VideoLabels label_id, const char *text);
     void start_video();
 
 private:
     GstElement *pipeline;
     GstElement *g_video_lbls[MAX_LBL];
-    guintptr video_window_handle;
     static const char *g_def_label[MAX_LBL];
 
-    static GstBusSyncReply bus_sync_handler(GstBus *bus, GstMessage *message, gpointer user_data);
-    static void realize_cb(GtkWidget *widget, gpointer data);
-    static gboolean delete_event_cb(GtkWidget *widget, GdkEvent *event, gpointer data);
     static void gst_pad_link_elements(GstElement *element, GstPad *pad, gpointer data);
 };
 


### PR DESCRIPTION
Closes #14

## What changed

- replace the X11 window-handle video overlay with an embedded `gtkglsink`/`glsinkbin` widget that works with native Wayland and XWayland
- replace raw `/dev/input/event*` scanning with SDL2 game-controller discovery, hot-plugging, and main-loop event handling
- enter fullscreen automatically when launched by Steam, add F11 toggling, and add controller labels with larger touch targets
- bundle SDL2 in the Flatpak and enable Wayland with fallback X11

## Why

The previous X11-specific video path prevented native Wayland use, raw event-number scanning was fragile and updated GTK from a worker thread, and the normal desktop window was a poor fit for SteamOS Gaming Mode.

## Impact

Steam Deck controls reconnect automatically, input is processed safely on GTK's main loop, and the video remains embedded under both Wayland and XWayland. Desktop launches stay windowed; Steam launches request fullscreen.

## Validation

- `git diff --check`
- parsed the application and workflow YAML files
- validated AppStream XML and SVG with `xmllint`
- GitHub Actions native C++ build passed
- GitHub Actions complete Flatpak build and artifact creation passed